### PR TITLE
Render percent completed with accurate progress icon

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -67,7 +67,7 @@ export default function Command() {
             <MenuBarExtra.Item
               title="Percent Completed"
               subtitle={`${percent}%`}
-              icon={getProgressIcon(percent! / 100)}
+              icon={getProgressIcon(percent! / 100, Color.SecondaryText)}
             />
             <MenuBarExtra.Item
               title="Last Updated"

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,5 @@
 import { MenuBarExtra, Icon, Color, open } from "@raycast/api";
-import { useFetch } from "@raycast/utils";
+import { getProgressIcon, useFetch } from "@raycast/utils";
 
 interface MigrationStatus {
   migration: string;
@@ -67,7 +67,7 @@ export default function Command() {
             <MenuBarExtra.Item
               title="Percent Completed"
               subtitle={`${percent}%`}
-              icon={Icon.CircleProgress}
+              icon={getProgressIcon(percent! / 100)}
             />
             <MenuBarExtra.Item
               title="Last Updated"


### PR DESCRIPTION
`@raycast/utils` provides a `getProgressIcon` utility method that we can use to render an accurate progress icon.

<img width="297" height="434" alt="image" src="https://github.com/user-attachments/assets/6a77e01c-3005-43f8-93b8-4b20cc3a87ca" />
